### PR TITLE
Update typings so all imports are correctly typed

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/chai-spies": "0.0.0",
     "@types/fs-extra": "0.0.35",
     "@types/glob": "^5.0.30",
-    "@types/lodash": "^4.14.40",
+    "@types/lodash": "^4.14.52",
     "@types/mkdirp": "^0.3.29",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.40",
@@ -57,7 +57,7 @@
     "mocha": "^2.3.3",
     "proxyquire": "^1.7.10",
     "tslint": "^4.4.2",
-    "typescript": "^2.0.3",
+    "typescript": "^2.1.6",
     "vscode": "^1.0.0"
   },
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,9 +3,9 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as mkdirp from 'mkdirp';
-const { curry, noop } = require('lodash'); // Typings for curry are broken
+import { curry, noop } from 'lodash';
 import { sync as globSync } from 'glob';
-const gitignoreToGlob = require('gitignore-to-glob'); // No typings exist yet
+import * as gitignoreToGlob from 'gitignore-to-glob';
 
 function invertGlob(pattern) {
   return pattern.replace(/^!/, '');
@@ -64,7 +64,7 @@ export function createFile(absolutePath: string): string {
 
 export function openFile(absolutePath: string): PromiseLike<string> {
   return vscode.workspace.openTextDocument(absolutePath)
-    .then((textDocument) => {
+    .then((textDocument): PromiseLike<string> => {
       if (textDocument) {
         vscode.window.showTextDocument(textDocument);
         return Promise.resolve(absolutePath);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
             "es6"
         ],
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "baseUrl": "types",
+        "typeRoots": ["types", "node_modules/@types"],
+        "skipLibCheck": true
     },
     "exclude": [
         "node_modules",

--- a/types/gitignore-to-glob/index.d.ts
+++ b/types/gitignore-to-glob/index.d.ts
@@ -1,0 +1,11 @@
+declare namespace GitignoreToGlob {
+  interface Options {
+    dirsToCheck?: string[],
+    string?: boolean
+  }
+}
+
+declare function GitignoreToGlob(gitignorePathOrContents: string, options?: GitignoreToGlob.Options): string[];
+declare function GitignoreToGlob(gitignorePath: string, dirsToCheck?: string[]): string[];
+
+export = GitignoreToGlob;


### PR DESCRIPTION
* Add typings for gitignore-to-glob in `types/`
* Update lodash typings to fix curry signature
* Enable skipLibCheck compiler option to fix lodash typing issue (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324)
* TypeScript to latest