### PR TITLE
Create folders by supplying trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ files anywhere in your workspace.
 
 * Fuzzy-matching autocomplete to create new file relative to existing path
 * Create new directories while creating a new file
+* Create a directory instead of a file by suffixing the file path with `/`
 * Ignores gitignored and workspace ignored directories
 
 ## Usage

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,6 +107,7 @@ export function createFileOrFolder(absolutePath: string): string {
 
 export function openFile(absolutePath: string): PromiseLike<string> {
   if (isFolderDescriptor(absolutePath)) {
+    vscode.window.showInformationMessage(`Folder created: ${absolutePath}`);
     return Promise.resolve(absolutePath);
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,10 @@ import { sync as globSync } from 'glob';
 const systemRoot =
   (platform() === 'win32') ? `${process.cwd().split(path.sep)[0]}\\` : '/';
 
+function isFolderDescriptor (filepath) {
+  return filepath.charAt(filepath.length - 1) === path.sep;
+}
+
 function invertGlob(pattern) {
   return pattern.replace(/^!/, '');
 }
@@ -86,18 +90,26 @@ export function directories(root: string): Promise<string[]> {
   });
 }
 
-export function createFile(absolutePath: string): string {
+export function createFileOrFolder(absolutePath: string): string {
   let directoryToFile = path.dirname(absolutePath);
 
   if (!fs.existsSync(absolutePath)) {
-    mkdirp.sync(directoryToFile);
-    fs.appendFileSync(absolutePath, '');
+    if (isFolderDescriptor(absolutePath)) {
+      mkdirp.sync(absolutePath);
+    } else {
+      mkdirp.sync(directoryToFile);
+      fs.appendFileSync(absolutePath, '');
+    }
   }
 
   return absolutePath;
 }
 
 export function openFile(absolutePath: string): PromiseLike<string> {
+  if (isFolderDescriptor(absolutePath)) {
+    return Promise.resolve(absolutePath);
+  }
+
   return vscode.workspace.openTextDocument(absolutePath)
     .then((textDocument): PromiseLike<string> => {
       if (textDocument) {
@@ -128,7 +140,7 @@ export function activate(context: vscode.ExtensionContext) {
           .then(showInputBox)
           .then(guardNoSelection)
           .then(resolveAbsolutePath)
-          .then(createFile)
+          .then(createFileOrFolder)
           .then(openFile)
           .then(noop, noop); // Silently handle rejections for now
       } else {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -370,7 +370,7 @@ describe('Advanced New File', () => {
       });
     });
 
-    it('creates a folder at given path', () => {
+    it('creates a folder at given path and shows information message', () => {
       let command;
       const registerCommand = (name, commandFn) => command = commandFn;
 
@@ -378,6 +378,7 @@ describe('Advanced New File', () => {
       const openTextDocument = chai.spy(() => Promise.resolve(textDocument));
       const showTextDocument = chai.spy();
       const showErrorMessage = chai.spy();
+      const showInformationMessage = chai.spy();
 
       const advancedNewFile = proxyquire('../src/extension', {
         vscode: {
@@ -391,6 +392,7 @@ describe('Advanced New File', () => {
             showErrorMessage,
             showQuickPick: () => Promise.resolve('path/to'),
             showInputBox: () => Promise.resolve('input/path/to/folder/'),
+            showInformationMessage,
             showTextDocument
           }
         },
@@ -414,6 +416,9 @@ describe('Advanced New File', () => {
 
         expect(showTextDocument)
           .to.not.have.been.called.with(textDocument);
+
+        expect(showInformationMessage)
+          .to.have.been.called.with(`Folder created: ${newFolderDescriptor}`);
 
         expect(fs.statSync(newFolderDescriptor).isDirectory())
           .to.be.true;


### PR DESCRIPTION
Hey, I'm loving your extension! The only thing I was missing was the ability to create folders by supplying a trailing slash (`/`). This PR adds that feature. Would be great to get this merged. Please let me know if I missed anything!

Best,
Max