### PR TITLE
Integration/pr21

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,10 +7,9 @@ import { curry, noop } from 'lodash';
 import * as gitignoreToGlob from 'gitignore-to-glob';
 import { platform } from 'os';
 import { sync as globSync } from 'glob';
-const systemRoot =
-  (platform() === 'win32') ? `${process.cwd().split(path.sep)[0]}\\` : '/';
-
-function isFolderDescriptor (filepath) {
+const systemRoot = (platform() === 'win32') ?
+  `${(path.resolve(vscode.workspace.rootPath) || './').split(path.sep)[0]}\\` : '/';
+function isFolderDescriptor(filepath) {
   return filepath.charAt(filepath.length - 1) === path.sep;
 }
 
@@ -60,7 +59,7 @@ function directoriesSync(root: string): string[] {
 export function showQuickPick(choices: Promise<string[]>) {
   return vscode.window.showQuickPick(choices, {
     placeHolder: 'First, select an existing path to create relative to ' +
-                 '(larger projects may take a moment to load)'
+    '(larger projects may take a moment to load)'
   });
 }
 
@@ -155,4 +154,4 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposable);
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,8 @@ import * as path from 'path';
 import * as mkdirp from 'mkdirp';
 import { curry, noop } from 'lodash';
 import * as gitignoreToGlob from 'gitignore-to-glob';
-import { platform } from 'os';
 import { sync as globSync } from 'glob';
-const systemRoot = (platform() === 'win32') ?
-  `${(path.resolve(vscode.workspace.rootPath) || './').split(path.sep)[0]}\\` : '/';
+
 function isFolderDescriptor(filepath) {
   return filepath.charAt(filepath.length - 1) === path.sep;
 }
@@ -21,8 +19,11 @@ function walkupGitignores(dir, found = []) {
   const gitignore = path.join(dir, '.gitignore');
   if (fs.existsSync(gitignore)) found.push(gitignore);
 
-  if (dir.toLowerCase() !== systemRoot.toLowerCase()) {
-    return walkupGitignores(path.resolve(dir, '..'), found);
+  const parentDir = path.resolve(dir, '..');
+  const reachedSystemRoot = dir === parentDir;
+
+  if (!reachedSystemRoot) {
+    return walkupGitignores(parentDir, found);
   } else {
     return found;
   }


### PR DESCRIPTION
@Kaffiend here it is with a platform agnostic way of determining when we've reached the root path. I tested this on Mac and Windows, but could you also test in your scenario where you're loading a workspace off a drive that is different than the one VS Code runs on?