### PR TITLE
explicit workspace exclude & repeat last 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ files anywhere in your workspace.
 * Fuzzy-matching autocomplete to create new file relative to existing path
 * Create new directories while creating a new file
 * Create a directory instead of a file by suffixing the file path with `/` as in `somedirectory/` to create the directory (thanks to [maximilianschmitt](https://github.com/maximilianschmitt))
-* Ignores gitignored and workspace ignored directories
+* Ignores gitignored and workspace `files.exclude` settings.
+* Additional option of adding `adv-new-file.exclude` settings to workspace settings just like native `files.exlude` except only it explicitly effects AdvancedNewFile plugin only.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ files anywhere in your workspace.
 * Create a directory instead of a file by suffixing the file path with `/` as in `somedirectory/` to create the directory (thanks to [maximilianschmitt](https://github.com/maximilianschmitt))
 * Ignores gitignored and workspace `files.exclude` settings.
 * Additional option of adding `adv-new-file.exclude` settings to workspace settings just like native `files.exlude` except it explicitly effects AdvancedNewFile plugin only.
-
+* Option for repeat last selection at top of directory list by setting `adv-new-file.repeatLast` to true.
+## Configuration Example
+```
+ "adv-new-file": {
+    "repeatLast": true,
+    "exclude": {
+      "node_modules": true,
+      "node_modules_electron": true,
+      "dev": true,
+      "dist": true
+    }
+  }
+```
 ## Usage
 
 * Command palette: "Advanced New File"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ files anywhere in your workspace.
 * Create new directories while creating a new file
 * Create a directory instead of a file by suffixing the file path with `/` as in `somedirectory/` to create the directory (thanks to [maximilianschmitt](https://github.com/maximilianschmitt))
 * Ignores gitignored and workspace `files.exclude` settings.
-* Additional option of adding `adv-new-file.exclude` settings to workspace settings just like native `files.exlude` except only it explicitly effects AdvancedNewFile plugin only.
+* Additional option of adding `adv-new-file.exclude` settings to workspace settings just like native `files.exlude` except it explicitly effects AdvancedNewFile plugin only.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",
     "glob": "^7.1.1",
     "lodash": "^4.17.2",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "vscode-cache": "^0.3.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,7 +140,6 @@ export function guardNoSelection(selection?: string): PromiseLike<string> {
 export function handleRepeatLast(selection): PromiseLike<string> {
   const repeatLast = vscode.workspace.getConfiguration('adv-new-file').get('repeatLast');
   if (repeatLast) {
-    console.log(selection);
     cache.put('last', selection);
   }
   return Promise.resolve(selection);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ function directoriesSync(root: string): string[] {
   results.unshift('/');
 
   const repeatLast = vscode.workspace.getConfiguration('adv-new-file').get('repeatLast');
-  if (repeatLast) {
+  if (repeatLast && cache.has('last')) {
     let last = cache.get('last', '/');
     results.unshift(last);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,8 +38,7 @@ function directoriesSync(root: string): string[] {
   const gitignoreGlobs =
     gitignoreFiles.map(gitignoreToGlob).reduce(flatten, []);
 
-  const configFilesExclude =
-    vscode.workspace.getConfiguration('files.exclude');
+  const configFilesExclude = Object.assign([], vscode.workspace.getConfiguration('adv-new-file.exclude'), vscode.workspace.getConfiguration('files.exclude'));
   const workspaceIgnored = Object.keys(configFilesExclude)
     .filter(key => configFilesExclude[key] === true);
   const workspaceIgnoredGlobs =


### PR DESCRIPTION
same as vscode native just doesnt remove from workspace directory tree and works where .gitignore fails.

need to update documentation to reflect that additional option.