### PR TITLE
Add a test that should fail on Windows

### DIFF
--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -69,13 +69,14 @@ describe('Advanced New File', () => {
     context('with a gitignore file', () => {
       const gitignoreFile = path.join(dummyProjectRoot, '.gitignore');
       before(() => {
-        fs.writeFileSync(gitignoreFile, 'ignored/**\nnested-ignored/');
+        fs.writeFileSync(gitignoreFile, 'ignored/**\nnested-ignored/\ndev/');
       });
       after(() => fs.unlinkSync(gitignoreFile));
 
       it('does not include gitignored directories', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
         expect(result).not.to.include('/ignored');
+        expect(result).not.to.include('/dev');
       });
 
       it('does not include nested gitignored directories', async () => {


### PR DESCRIPTION
@Kaffiend I'm not able to reproduce #27 on Mac, so I'm trying here to get a failing test case on Appveyor (Windows CI). Just pushed an initial attempt, if it doesn't fail on Windows I could use your help trying to get a failing test case setup.