### PR TITLE
Multiroot support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.5.1",
   "publisher": "patbenatar",
   "engines": {
-    "vscode": "^1.5.0"
+    "vscode": "^1.18.0"
   },
   "homepage": "https://github.com/patbenatar/vscode-advanced-new-file",
   "repository": {
@@ -78,7 +78,7 @@
     "tslint": "^4.4.2",
     "typescript": "^2.1.6",
     "vsce": "^1.18.0",
-    "vscode": "^1.0.0"
+    "vscode": "^1.1.0"
   },
   "dependencies": {
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ function directoriesSync(root: string): string[] {
 
   const results = globSync('**', { cwd: root, ignore })
     .filter(f => fs.statSync(path.join(root, f)).isDirectory())
-    .map(f => path.sep + path.normalize(f));
+    .map(f => path.normalize(f));
 
   return results;
 }
@@ -196,6 +196,13 @@ export function activate(context: vscode.ExtensionContext) {
       const resolverArgsCount = 2;
 
       const currentFilePicks = currentFileRoot ? directories(currentFileRoot) : Promise.resolve([]);
+      const resolveAbsolutePath = (typedPath) => {
+        if (!currentFileRoot) {
+          return typedPath;
+        }
+
+        return path.resolve(currentFileRoot, typedPath);
+      }
 
       const choices = currentFilePicks
         .then(toQuickPickItems)
@@ -216,7 +223,7 @@ export function activate(context: vscode.ExtensionContext) {
         .then(cacheSelection(cache))
         .then(showInputBox)
         .then(guardNoSelection)
-        //.then(resolveAbsolutePath)
+        .then(resolveAbsolutePath)
         .then(createFileOrFolder)
         .then(openFile)
         .then(noop, noop); // Silently handle rejections for now

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ function directoriesSync(root: string): string[] {
 
   const results = globSync('**', { cwd: root, ignore })
     .filter(f => fs.statSync(path.join(root, f)).isDirectory())
-    .map(f => '/' + f);
+    .map(f => path.sep + path.normalize(f));
 
   return results;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,48 +188,54 @@ export function activate(context: vscode.ExtensionContext) {
       const editor = vscode.window.activeTextEditor;
       let currentFileRoot: string = undefined;
 
-      if (editor) {
-        currentFileRoot = vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
-      }
-
-      const cache = new Cache(context, `workspace:${currentFileRoot}`);
-      const resolverArgsCount = 2;
-
-      const currentFilePicks = currentFileRoot ? directories(currentFileRoot) : Promise.resolve([]);
-      const resolveAbsolutePath = (typedPath) => {
-        if (!currentFileRoot) {
-          return typedPath;
+      if (vscode.workspace.workspaceFolders.length > 0) {
+        if (editor) {
+          currentFileRoot = vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
         }
 
-        return path.resolve(currentFileRoot, typedPath);
+        const cache = new Cache(context, `workspace:${currentFileRoot}`);
+        const resolverArgsCount = 2;
+
+        const currentFilePicks = currentFileRoot ? directories(currentFileRoot) : Promise.resolve([]);
+        const resolveAbsolutePath = (typedPath) => {
+          if (!currentFileRoot) {
+            return typedPath;
+          }
+
+          return path.resolve(currentFileRoot, typedPath);
+        }
+
+        const choices = currentFilePicks
+          .then(toQuickPickItems)
+          .then((itemsBeforeWorkspaceRoots) => {
+            return vscode.workspace.workspaceFolders.reduce(
+              (items, wsFolder) => prependChoice(
+                wsFolder.uri.fsPath,
+                `- workspace ${wsFolder.name} root`)(items),
+              itemsBeforeWorkspaceRoots
+            );
+          })
+          .then(prependChoice(currentEditorPath(), '- current file'))
+          .then(prependChoice(lastSelection(cache), '- last selection'));
+
+        return showQuickPick(choices)
+          .then(unwrapSelection)
+          .then(guardNoSelection)
+          .then(cacheSelection(cache))
+          .then(showInputBox)
+          .then(guardNoSelection)
+          .then(resolveAbsolutePath)
+          .then(createFileOrFolder)
+          .then(openFile)
+          .then(noop, noop); // Silently handle rejections for now
+
+      } else {
+        return vscode.window.showErrorMessage(
+          'It doesn\'t look like you have a folder opened in your workspace. ' +
+          'Try opening a folder first.'
+        );
       }
-
-      const choices = currentFilePicks
-        .then(toQuickPickItems)
-        .then((itemsBeforeWorkspaceRoots) => {
-          return vscode.workspace.workspaceFolders.reduce(
-            (items, wsFolder) => prependChoice(
-              wsFolder.uri.fsPath,
-              `- workspace ${wsFolder.name} root`)(items),
-            itemsBeforeWorkspaceRoots
-          );
-        })
-        .then(prependChoice(currentEditorPath(), '- current file'))
-        .then(prependChoice(lastSelection(cache), '- last selection'));
-
-      return showQuickPick(choices)
-        .then(unwrapSelection)
-        .then(guardNoSelection)
-        .then(cacheSelection(cache))
-        .then(showInputBox)
-        .then(guardNoSelection)
-        .then(resolveAbsolutePath)
-        .then(createFileOrFolder)
-        .then(openFile)
-        .then(noop, noop); // Silently handle rejections for now
-
     });
-
   context.subscriptions.push(disposable);
 }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -59,11 +59,11 @@ describe('Advanced New File', () => {
   describe('directories', () => {
     const dummyProjectRoot = path.join(__dirname, 'dummy_project');
 
-    it('only returns directories, prepended with /', async () => {
+    it('only returns directories', async () => {
       let result = await advancedNewFile.directories(dummyProjectRoot);
 
-      expect(result).to.include('/folder');
-      expect(result).not.to.include('/folder/file');
+      expect(result).to.include('folder');
+      expect(result).not.to.include(path.join('folder', 'file'));
     });
 
     context('with a gitignore file', () => {
@@ -75,12 +75,12 @@ describe('Advanced New File', () => {
 
       it('does not include gitignored directories', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).not.to.include('/ignored');
+        expect(result).not.to.include('ignored');
       });
 
       it('does not include nested gitignored directories', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).not.to.include('/folder/nested-ignored');
+        expect(result).not.to.include(path.join('folder', 'nested-ignored'));
       });
     });
 
@@ -103,8 +103,8 @@ describe('Advanced New File', () => {
       it('ignores as specified in both gitignore files', async () => {
         let result = await advancedNewFile.directories(testProjectRoot);
 
-        expect(result).not.to.include('/nested-ignored');
-        expect(result).not.to.include('/nested');
+        expect(result).not.to.include('nested-ignored');
+        expect(result).not.to.include('nested');
       });
     });
 
@@ -131,12 +131,12 @@ describe('Advanced New File', () => {
 
       it('does not include directories with a true value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).not.to.include('/ignored');
+        expect(result).not.to.include('ignored');
       });
 
       it('includes directories with a false value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).to.include('/folder');
+        expect(result).to.include('folder');
       });
     });
 
@@ -165,12 +165,12 @@ describe('Advanced New File', () => {
 
       it('does not include directories with a true value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).not.to.include('/ignored');
+        expect(result).not.to.include('ignored');
       });
 
       it('includes directories with a false value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
-        expect(result).to.include('/folder');
+        expect(result).to.include('folder');
       });
     });
   });
@@ -224,7 +224,7 @@ describe('Advanced New File', () => {
 
     context('creating folder', () => {
       context('folder does not exist', () => {
-        const newFolderDescriptor = path.join(tmpDir, 'path/to/folder') +
+        const newFolderDescriptor = path.join(tmpDir, 'path', 'to', 'folder') +
           path.sep;
 
         after(() => fs.rmdirSync(newFolderDescriptor));
@@ -235,12 +235,12 @@ describe('Advanced New File', () => {
           expect(fs.statSync(path.join(tmpDir, 'path')).isDirectory())
             .to.be.true;
 
-          expect(fs.statSync(path.join(tmpDir, 'path/to')).isDirectory())
+          expect(fs.statSync(path.join(tmpDir, 'path', 'to')).isDirectory())
             .to.be.true;
         });
 
         it('creates a folder', () => {
-          expect(fs.statSync(path.join(tmpDir, 'path/to/folder')).isDirectory())
+          expect(fs.statSync(path.join(tmpDir, 'path', 'to', 'folder')).isDirectory())
             .to.be.true;
         });
       });
@@ -620,8 +620,8 @@ describe('Advanced New File', () => {
           },
           window: {
             showErrorMessage,
-            showQuickPick: () => Promise.resolve({ label: 'path/to' }),
-            showInputBox: () => Promise.resolve('input/path/to/file.rb'),
+            showQuickPick: () => Promise.resolve({ label: path.join('path', 'to') }),
+            showInputBox: () => Promise.resolve(path.join('input', 'path', 'to', 'file.rb')),
             showTextDocument
           }
         },
@@ -642,7 +642,7 @@ describe('Advanced New File', () => {
       advancedNewFile.activate(context);
 
       const newFileDescriptor =
-        path.join(tmpDir, 'path/to/input/path/to/file.rb');
+        path.join(tmpDir, 'path', 'to', 'input', 'path', 'to', 'file.rb');
 
       return command().then(() => {
         expect(openTextDocument)
@@ -685,8 +685,8 @@ describe('Advanced New File', () => {
           },
           window: {
             showErrorMessage,
-            showQuickPick: () => Promise.resolve({ label: 'path/to' }),
-            showInputBox: () => Promise.resolve('input/path/to/folder/'),
+            showQuickPick: () => Promise.resolve({ label: path.join('path', 'to') }),
+            showInputBox: () => Promise.resolve(path.join('input', 'path', 'to', 'folder')),
             showInformationMessage,
             showTextDocument
           }
@@ -708,7 +708,7 @@ describe('Advanced New File', () => {
       advancedNewFile.activate(context);
 
       const newFolderDescriptor =
-        path.join(tmpDir, 'path/to/input/path/to/folder/');
+        path.join(tmpDir, 'path', 'to', 'input', 'path', 'to', 'folder');
 
       return command().then(() => {
         expect(openTextDocument)
@@ -756,8 +756,8 @@ describe('Advanced New File', () => {
             },
             window: {
               showErrorMessage,
-              showQuickPick: () => Promise.resolve({ label: 'path/to' }),
-              showInputBox: () => Promise.resolve('input/path/to/folder/'),
+              showQuickPick: () => Promise.resolve({ label: path.join('path', 'to') }),
+              showInputBox: () => Promise.resolve(path.join('input', 'path', 'to', 'folder')),
               showInformationMessage,
               showTextDocument
             }
@@ -779,7 +779,7 @@ describe('Advanced New File', () => {
         advancedNewFile.activate(context);
 
         const newFolderDescriptor =
-          path.join(tmpDir, 'path/to/input/path/to/folder/');
+         path.join(tmpDir, 'path', 'to', 'input', 'path', 'to', 'folder');
 
         return command().then(() => {
           expect(openTextDocument)


### PR DESCRIPTION
This PR implements multiroot support for this extension. The single workspace root selection is replaced with all roots in whatever order they are iterated over. Also, the discovered sibling directories for the currently opened editor are converted to a platform appropriate format.
