### PR TITLE
Multi root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ install:
   - npm run vscode:prepublish
 
 script:
+  - npm run lint
   - npm test --silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.0
+
+## What's New
+* Support for multi-root workspaces
+
+## Misc
+* Dropped support for VS Code versions < 1.16.0 (August 2017) so we can use
+  Node 7.6+, enabling a large refactor to use async/await
+
 # 0.5.1
 
 ## What's New

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/bluebird": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
-      "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
-      "dev": true
-    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
@@ -262,11 +256,6 @@
       "requires": {
         "inherits": "2.0.3"
       }
-    },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boolbase": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "advanced-new-file",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -256,6 +256,11 @@
       "requires": {
         "inherits": "2.0.3"
       }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boolbase": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/bluebird": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
+      "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.5.1",
   "publisher": "patbenatar",
   "engines": {
-    "vscode": "^1.5.0"
+    "vscode": "^1.16.0"
   },
   "homepage": "https://github.com/patbenatar/vscode-advanced-new-file",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
-    "release": "vsce publish"
+    "release": "vsce publish",
+    "lint": "tslint src/**"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.18",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,13 @@
       "title": "AdvancedNewFile configuration",
       "properties": {
         "advancedNewFile.exclude": {
-          "type": ["object", "null"],
-          "additionalProperties": { "type": "boolean" },
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "boolean"
+          },
           "default": null,
           "description": "Directories to ignore in auto-complete"
         },
@@ -81,6 +86,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.1",
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",
     "glob": "^7.1.1",
     "lodash": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "lint": "tslint src/**"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.18",
     "@types/chai": "^3.4.34",
     "@types/chai-as-promised": "0.0.29",
     "@types/chai-spies": "0.0.0",
@@ -88,7 +87,6 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.5.1",
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",
     "glob": "^7.1.1",
     "lodash": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "release": "vsce publish"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.18",
     "@types/chai": "^3.4.34",
     "@types/chai-as-promised": "0.0.29",
     "@types/chai-spies": "0.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,7 @@ export async function showInputBox(
     });
 
     return path.join(baseDirectory.fsLocation.absolute, input);
-  } catch {
+  } catch (e) {
     return;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,14 @@ export async function openFile(absolutePath: string): Promise<void> {
 
 export function lastSelection(cache: Cache): DirectoryOption {
   if (!cache.has('last')) return;
-  return cache.get('last') as DirectoryOption;
+  const value = cache.get('last')
+
+  if (typeof value === 'object') {
+    return value as DirectoryOption;
+  } else {
+    cache.forget('last');
+    return;
+  }
 }
 
 export function workspaceRoots(): WorkspaceRoot[] {
@@ -246,7 +253,10 @@ export function currentEditorPathOption(
   if (!currentFileRoot) return;
 
   const rootMatcher = new RegExp(`^${currentFileRoot.rootPath}`);
-  const relativeCurrentFilePath = currentFilePath.replace(rootMatcher, '');
+  let relativeCurrentFilePath = currentFilePath.replace(rootMatcher, '');
+
+  relativeCurrentFilePath =
+    relativeCurrentFilePath === '' ? path.sep : relativeCurrentFilePath;
 
   const displayText = currentFileRoot.multi ?
     path.join(path.sep, currentFileRoot.baseName, relativeCurrentFilePath) :

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,7 +182,7 @@ export async function openFile(absolutePath: string): Promise<void> {
 
 export function lastSelection(cache: Cache): DirectoryOption {
   if (!cache.has('last')) return;
-  const value = cache.get('last')
+  const value = cache.get('last');
 
   if (typeof value === 'object') {
     return value as DirectoryOption;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -404,11 +404,19 @@ describe('Advanced New File', () => {
     });
 
     it('returns the cached last selection', () => {
+      const lastSelection: AdvancedNewFile.DirectoryOption = {
+        displayText: 'foo',
+        fsLocation: {
+          absolute: '/',
+          relative: '/'
+        }
+      }
       const cache = {
         has: () => true,
-        get: () => '/cached/value'
+        get: () => lastSelection
       }
-      expect(AdvancedNewFile.lastSelection(cache)).to.eq('/cached/value');
+
+      expect(AdvancedNewFile.lastSelection(cache)).to.eq(lastSelection);
     });
   });
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -443,26 +443,26 @@ describe('Advanced New File', () => {
     });
   });
 
-  describe('cacheSelection', () => {
-    it('returns a function that when called writes the value to cache', () => {
-      const cache = {
-        put: chai.spy()
-      }
-      const fn = advancedNewFile.cacheSelection(cache);
-      fn('/selection');
+  // describe('cacheSelection', () => {
+  //   it('returns a function that when called writes the value to cache', () => {
+  //     const cache = {
+  //       put: chai.spy()
+  //     }
+  //     const fn = advancedNewFile.cacheSelection(cache);
+  //     fn('/selection');
 
-      expect(cache.put).to.have.been.called.with('last', '/selection');
-    });
+  //     expect(cache.put).to.have.been.called.with('last', '/selection');
+  //   });
 
-    it('returns a function that returns the selection', () => {
-      const cache = {
-        put: () => true
-      }
-      const fn = advancedNewFile.cacheSelection(cache);
+  //   it('returns a function that returns the selection', () => {
+  //     const cache = {
+  //       put: () => true
+  //     }
+  //     const fn = advancedNewFile.cacheSelection(cache);
 
-      expect(fn('/selection')).to.eq('/selection');
-    });
-  });
+  //     expect(fn('/selection')).to.eq('/selection');
+  //   });
+  // });
 
   describe('lastSelection', () => {
     context('empty cache', () => {
@@ -558,34 +558,34 @@ describe('Advanced New File', () => {
     });
   });
 
-  describe('prependChoice', () => {
-    it('returns a function that when called with a list of choices, adds a ' +
-       'choice with given label and description to the set', () => {
+  // describe('prependChoice', () => {
+  //   it('returns a function that when called with a list of choices, adds a ' +
+  //      'choice with given label and description to the set', () => {
 
-      const fn = advancedNewFile.prependChoice('label', 'description');
-      let choices: vscode.QuickPickItem[] = [{
-        label: 'existing-label',
-        description: 'existing-description'
-      }];
+  //     const fn = advancedNewFile.prependChoice('label', 'description');
+  //     let choices: vscode.QuickPickItem[] = [{
+  //       label: 'existing-label',
+  //       description: 'existing-description'
+  //     }];
 
-      expect(fn(choices)).to.include({
-        label: 'label',
-        description: 'description'
-      });
-    });
+  //     expect(fn(choices)).to.include({
+  //       label: 'label',
+  //       description: 'description'
+  //     });
+  //   });
 
-    context('no label given', () => {
-      it('does not add a choice', () => {
-        const fn = advancedNewFile.prependChoice(null, 'description');
-        let choices: vscode.QuickPickItem[] = [{
-          label: 'existing-label',
-          description: 'existing-description'
-        }];
+  //   context('no label given', () => {
+  //     it('does not add a choice', () => {
+  //       const fn = advancedNewFile.prependChoice(null, 'description');
+  //       let choices: vscode.QuickPickItem[] = [{
+  //         label: 'existing-label',
+  //         description: 'existing-description'
+  //       }];
 
-        expect(fn(choices)).to.eq(choices);
-      })
-    });
-  });
+  //       expect(fn(choices)).to.eq(choices);
+  //     })
+  //   });
+  // });
 
   describe('command integration tests', () => {
     const tmpDir = path.join(__dirname, 'createFileOrFolder.tmp');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -2,7 +2,6 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as spies from 'chai-spies';
 import * as vscode from 'vscode';
-// import * as advancedNewFile from '../src/extension';
 import * as AdvancedNewFile from '../src/extension';
 import * as proxyquire from 'proxyquire';
 import * as path from 'path';
@@ -50,8 +49,8 @@ describe('Advanced New File', () => {
       let result = await AdvancedNewFile.directories(dummyProjectRoot);
       let relativePaths = result.map(r => r.relative);
 
-      expect(relativePaths).to.include('/folder');
-      expect(relativePaths).not.to.include('/folder/file');
+      expect(relativePaths).to.include(`${path.sep}folder`);
+      expect(relativePaths).not.to.include(`${path.sep}folder${path.sep}file`);
     });
 
     context('with a gitignore file', () => {
@@ -65,14 +64,14 @@ describe('Advanced New File', () => {
         let result = await AdvancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).not.to.include('/ignored');
+        expect(relativePaths).not.to.include(`${path.sep}ignored`);
       });
 
       it('does not include nested gitignored directories', async () => {
         let result = await AdvancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).not.to.include('/folder/nested-ignored');
+        expect(relativePaths).not.to.include(`${path.sep}folder${path.sep}nested-ignored`);
       });
     });
 
@@ -96,8 +95,8 @@ describe('Advanced New File', () => {
         let result = await AdvancedNewFile.directories(testProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).not.to.include('/nested-ignored');
-        expect(relativePaths).not.to.include('/nested');
+        expect(relativePaths).not.to.include(`${path.sep}nested-ignored`);
+        expect(relativePaths).not.to.include(`${path.sep}nested`);
       });
     });
 
@@ -126,14 +125,14 @@ describe('Advanced New File', () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).not.to.include('/ignored');
+        expect(relativePaths).not.to.include(`${path.sep}ignored`);
       });
 
       it('includes directories with a false value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).to.include('/folder');
+        expect(relativePaths).to.include(`${path.sep}folder`);
       });
     });
 
@@ -164,14 +163,14 @@ describe('Advanced New File', () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).not.to.include('/ignored');
+        expect(relativePaths).not.to.include(`${path.sep}ignored`);
       });
 
       it('includes directories with a false value', async () => {
         let result = await advancedNewFile.directories(dummyProjectRoot);
         let relativePaths = result.map(r => r.relative);
 
-        expect(relativePaths).to.include('/folder');
+        expect(relativePaths).to.include(`${path.sep}folder`);
       });
     });
   });


### PR DESCRIPTION
@ilkka this is an alternate approach to the multi-root solution. I took inspiration from your PR, but expanded on the functionality to include:

* backwards compatibility for a couple VS Code versions before 1.18
* displaying directory options from all workspace folders, not just the folder of the current editor's workspace

Unrelated to multi-root: I took this opportunity to refactor to async/await instead of promise chains, which makes the code easier to work with.

When you have a moment please take a look, pull it down and play with it. Let me know if the behavior is what you'd expect in multi-root. Thanks!