### PR TITLE
Add brace expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ files anywhere in your workspace.
   AdvancedNewFile plugin only. (thanks to [Kaffiend](https://github.com/Kaffiend))
 * Control the order of top convenient options ("last selection", "current file",
   etc) via config setting `advancedNewFile.convenienceOptions`
+* Brace expansion - expand braces into multiple files. Entering `index.{html,css}` will create and open `index.html` and `index.css`. (thanks to [chuckhendo](https://github.com/chuckhendo))
 
 ## Configuration Example
 
@@ -32,7 +33,8 @@ files anywhere in your workspace.
   "dist": true
 },
 "advancedNewFile.showInformationMessages": true,
-"advancedNewFile.convenienceOptions": ["last", "current", "root"]
+"advancedNewFile.convenienceOptions": ["last", "current", "root"],
+"advancedNewFile.expandBraces": false
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
             "root"
           ],
           "description": "Convenience options display at the top of the list. Control which ones you see and in what order."
+        },
+        "advancedNewFile.expandBraces": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js"
         }
       }
     }
@@ -96,6 +101,7 @@
     "vscode": "^1.1.18"
   },
   "dependencies": {
+    "braces": "^3.0.2",
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",
     "glob": "^7.1.1",
     "lodash": "^4.17.2",


### PR DESCRIPTION
closes #69 

- adds new setting: `advancedNewFile.expandBraces`. This defaults to false
- supports braces to create new files. Also supports multiple braces (`folder/subfolder{1,2}/file{1,2}.{html,css}`)
- wrote unit tests for expandBraces

There were some failing unit tests, but these were failing before I even started, so I'm not sure if maybe there was something wrong with my configuration or something else.