### PR TITLE
feat: Allow names in multiroot workspaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,7 +237,7 @@ export function workspaceRoots(): WorkspaceRoot[] {
     return vscode.workspace.workspaceFolders.map((folder) => {
       return {
         rootPath: folder.uri.fsPath,
-        baseName: path.basename(folder.uri.fsPath),
+        baseName: folder.name || path.basename(folder.uri.fsPath),
         multi
       };
     });


### PR DESCRIPTION
Workspace folders can have `name` properties. It may be useful to use the name instead of the base path, for example in cases when the base folder name is the same.

https://code.visualstudio.com/api/references/vscode-api#WorkspaceFolder
https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-file-schema


Before:
![image](https://user-images.githubusercontent.com/7453394/124030895-f1645a00-d9f6-11eb-9c27-7ca820bb0ab1.png)


After:
![image](https://user-images.githubusercontent.com/7453394/124030843-dd205d00-d9f6-11eb-9ae6-cc40b7c386c3.png)
