### PR TITLE
Add escape characters to current path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -273,7 +273,8 @@ export function currentEditorPathOption(
 
   if (!currentFileRoot) return;
 
-  const rootMatcher = new RegExp(`^${currentFileRoot.rootPath}`);
+  const rootPath = currentFileRoot.rootPath.replace(/[\/.*+?^${}()|[\]\\]/g, '\\$&');
+  const rootMatcher = new RegExp(rootPath);
   let relativeCurrentFilePath = currentFilePath.replace(rootMatcher, '');
 
   relativeCurrentFilePath =


### PR DESCRIPTION
RegEx gets path with special characters. It's add escape characters before them.

Issue #93.