### PR TITLE
Ignore symbolic links when loading directories

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,10 @@ function directoriesSync(root: string): FSLocation[] {
         absolute: path.join(root, f)
       };
     })
-    .filter(f => fs.statSync(f.absolute).isDirectory())
+    .filter(f => {
+      const stat = fs.lstatSync(f.absolute);
+      return !stat.isSymbolicLink() && stat.isDirectory();
+    })
     .map(f => f);
 
   return results;


### PR DESCRIPTION
Fixes #74

The only difference between `statSync` and `lstatSync` is that the latter handles symbolic links while the former causes an error. Then we can ignore symbolic links.

https://nodejs.org/api/fs.html#fslstatpath-options-callback