### PR TITLE
Add brace expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+
+## What's New
+* Adds an `advancedNewFile.expandBraces` configuration option to expand braces in filepath to create and open multiple files: `/path/to/file.{tsx,spec.tsx} => [/path/to/file.tsx, /path/to/file.spec.tsx]`
+
 # 1.2.2
 
 ## Misc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ files anywhere in your workspace.
   AdvancedNewFile plugin only. (thanks to [Kaffiend](https://github.com/Kaffiend))
 * Control the order of top convenient options ("last selection", "current file",
   etc) via config setting `advancedNewFile.convenienceOptions`
-* Brace expansion - expand braces into multiple files. Entering `index.{html,css}` will create and open `index.html` and `index.css`. (thanks to [chuckhendo](https://github.com/chuckhendo))
+* Brace expansion - expand braces into multiple files. Entering `index.{html,css}` will create and open `index.html` and `index.css`. (thanks to [chuckhendo](https://github.com/chuckhendo) and [timlogemann](https://github.com/timlogemann))
 
 ## Configuration Example
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ files anywhere in your workspace.
   AdvancedNewFile plugin only. (thanks to [Kaffiend](https://github.com/Kaffiend))
 * Control the order of top convenient options ("last selection", "current file",
   etc) via config setting `advancedNewFile.convenienceOptions`
+* Brace expansion - expand braces into multiple files. Entering `index.{html,css}` will create and open `index.html` and `index.css`. (thanks to [chuckhendo](https://github.com/chuckhendo))
 
 ## Configuration Example
 
@@ -32,7 +33,8 @@ files anywhere in your workspace.
   "dist": true
 },
 "advancedNewFile.showInformationMessages": true,
-"advancedNewFile.convenienceOptions": ["last", "current", "root"]
+"advancedNewFile.convenienceOptions": ["last", "current", "root"],
+"advancedNewFile.expandBraces": false
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "advanced-new-file",
   "displayName": "advanced-new-file",
   "description": "Create files anywhere in your workspace from the keyboard",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "publisher": "patbenatar",
   "engines": {
     "vscode": "^1.17.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
             "root"
           ],
           "description": "Convenience options display at the top of the list. Control which ones you see and in what order."
+        },
+        "advancedNewFile.expandBraces": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js"
         }
       }
     }
@@ -96,6 +101,7 @@
     "vscode": "^1.1.18"
   },
   "dependencies": {
+    "braces": "^3.0.2",
     "gitignore-to-glob": "github:patbenatar/gitignore-to-glob",
     "glob": "^7.1.1",
     "lodash": "^4.17.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,7 +225,14 @@ export async function openFile(absolutePath: string): Promise<void> {
     const textDocument = await vscode.workspace.openTextDocument(absolutePath);
 
     if (textDocument) {
-      vscode.window.showTextDocument(textDocument, { preview: false });
+      const shouldExpandBraces =
+    vscode.workspace.getConfiguration('advancedNewFile').get('expandBraces');
+
+      if (shouldExpandBraces) {
+        vscode.window.showTextDocument(textDocument, { preview: false });
+      } else {
+        vscode.window.showTextDocument(textDocument, ViewColumn.Active);
+      }
     }
   }
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -396,6 +396,7 @@ describe('Advanced New File', () => {
                 workspace: {
                   openTextDocument,
                   getConfiguration: mockGetConfiguration({
+                    expandBraces: false,
                     showInformationMessages: false
                   })
                 },


### PR DESCRIPTION
Closes https://github.com/patbenatar/vscode-advanced-new-file/issues/69

The original PR https://github.com/patbenatar/vscode-advanced-new-file/pull/73 seems to have been abandoned, so I decided to fix it myself (it was my  feature request after all).

* updated the changelog and package version
* fixed a broken test
* added a quickfix to maintain the original behavior when opening a new file if expandBraces is off. The next step could be to only apply the new behavior if multiple files are opened.