### PR TITLE
bug: broken symlink crashes. #125

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,14 @@ function directoriesSync(root: string): FSLocation[] {
         absolute: path.join(root, f)
       };
     })
-    .filter(f => fs.statSync(f.absolute).isDirectory())
+    .filter(f => {
+      try {
+        return fs.statSync(f.absolute).isDirectory()
+      }
+      catch(e) {
+        return false;
+      }
+    })
     .map(f => f);
 
   return results;


### PR DESCRIPTION
I could not ran the code because i could not ran npm install due to errors. However, this should fix the symbolic link bug. 